### PR TITLE
Optimized yum calls to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,20 @@ FROM centos:centos7
 MAINTAINER perfSONAR <perfsonar-user@perfsonar.net>
 
 
-RUN yum -y install epel-release
-RUN yum -y install http://software.internet2.edu/rpms/el7/x86_64/main/RPMS/perfSONAR-repo-0.8-1.noarch.rpm 
-RUN yum -y update; yum clean all
-RUN yum -y install perfsonar-testpoint
-RUN yum -y install supervisor rsyslog net-tools sysstat iproute bind-utils tcpdump # grab a few other needed tools
+RUN yum -y install \
+    epel-release \
+    http://software.internet2.edu/rpms/el7/x86_64/main/RPMS/perfSONAR-repo-0.8-1.noarch.rpm \
+ && yum -y install \
+    bind-utils \
+    iproute \
+    net-tools \
+    perfsonar-testpoint \
+    rsyslog \
+    supervisor \
+    sysstat \ 
+    tcpdump \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # -----------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After editing the configuration files, exit the container and commit the change.
 > docker commit -m "added config settings" containerID perfsonar/testpoint
 
 Run the container:
->docker run --privileged -d -P --net=host -v "/var/run" perfsonar/testpoint
+>docker run --privileged -d -P --net=host perfsonar/testpoint
 
 ## Testing
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -36,8 +36,7 @@ command=/usr/bin/python /usr/libexec/pscheduler/daemons/scheduler --daemon --pid
 chown=pscheduler:pscheduler
 command=/usr/bin/python /usr/libexec/pscheduler/daemons/runner --daemon --pid-file /var/run/pscheduler-runner.pid --dsn @/etc/pscheduler/database/database-dsn 
 
-[program:perfsonar_meshconfig_agent]
+[program:psconfig_pscheduler_agent]
 chown=perfsonar:perfsonar
-command=/usr/lib/perfsonar/bin/perfsonar_meshconfig_agent --config=/etc/perfsonar/meshconfig-agent.conf --logger=/etc/perfsonar/meshconfig-agent-logger.conf --pidfile=/var/run/perfsonar-meshconfig-agent.pid --user=perfsonar --group=perfsonar
-autorestart=false				; dont autorestart; this daemon exits if not configured
+command=/usr/lib/perfsonar/bin/psconfig_pscheduler_agent --config=/etc/perfsonar/psconfig/pscheduler-agent.json --logger=/etc/perfsonar/psconfig/pscheduler-agent-logger.conf --pidfile=/var/run/psconfig-pscheduler-agent.pid --user=perfsonar --group=perfsonar
 


### PR DESCRIPTION
I made some optimizations on the yum calls to clear the cache before generating an intermediate image and got a 47% size reduction of the final image (from 1.17GB to 617MB).