### PR TITLE
fix: update permissions on /var/lib/pgsql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY postgresql/pg_hba.conf /var/lib/pgsql/$PG_VERSION/data/pg_hba.conf
 
 # Change own user
 RUN chown -R postgres:postgres /var/lib/pgsql/$PG_VERSION/data/*
+RUN chmod 0755 /var/lib/pgsql
 
 #Start postgresql
 RUN su - postgres -c "/usr/pgsql-10/bin/pg_ctl start -w -t 60" \


### PR DESCRIPTION
This directory had owner/group of root/root with a 0700 mode.
Change the mode to 0755 so that postgresql can still read the subdirs.
Note that the subdirs are still 0700 (with owner of postgres),
so this should not expose any data.

Fixes #18