### PR TITLE
ADD -> COPY in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY rsyslog/owamp-syslog.conf /etc/rsyslog.d/owamp-syslog.conf
 # -----------------------------------------------------------------------------
 
 RUN mkdir -p /var/log/supervisor 
-ADD supervisord.conf /etc/supervisord.conf
+COPY supervisord.conf /etc/supervisord.conf
 
 # The following ports are used:
 # pScheduler: 443


### PR DESCRIPTION
This is a pull request suggesting the line in `Dockerfile`:
```
ADD supervisord.conf /etc/supervisord.conf
```
be updated to use `COPY`.

From the [Dockle container image linter](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0009): "`ADD` instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities."