### PR TITLE
Let supervisord manage daemons for bugfix

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -22,19 +22,31 @@ command=/usr/bin/pidproxy /var/run/httpd.pid /bin/bash -c "/usr/sbin/httpd -DFOR
 
 [program:pscheduler-ticker]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/ticker --daemon --pid-file /var/run/pscheduler-ticker.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/ticker --pid-file /var/run/pscheduler-ticker.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:pscheduler-archiver]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/archiver --daemon --pid-file /var/run/pscheduler-archiver.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/archiver --pid-file /var/run/pscheduler-archiver.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:pscheduler-scheduler]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/scheduler --daemon --pid-file /var/run/pscheduler-scheduler.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/scheduler --pid-file /var/run/pscheduler-scheduler.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:pscheduler-runner]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/runner --daemon --pid-file /var/run/pscheduler-runner.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/runner --pid-file /var/run/pscheduler-runner.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:psconfig_pscheduler_agent]
 chown=perfsonar:perfsonar


### PR DESCRIPTION
Fix for crashing runner.  Container was unusable without this fix.

Simple jobs like `pscheduler task idle --duration PT2S` would not run and fail with

`Run has not completed.`

No jobs would run unless either a "print" or log statement was put at the top of /usr/libexec/pscheduler/daemons/runner` in `main_program()` due to crashing runner.  This fix seems like it is the proper approach to running daemons with supervisord.  This smells like a race condition and this version still does not capture output from the runner daemon but "fixes" the problems.

Without this fix, and running the runner in a separate shell, it will get the following error.
```
Traceback (most recent call last):
  File "/usr/libexec/pscheduler/daemons/runner", line 1070, in <module>
    main_program()
  File "/usr/libexec/pscheduler/daemons/runner", line 949, in main_program
    db.notifies.pop(0)
IndexError: pop from empty list
```
