### PR TITLE
Fixes for Postgresql on Kaniko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ ENV PGVERSION 10
 # Set the environment variables
 ENV PGDATA /var/lib/pgsql/10/data
 
+# Create run directory (using /run for Kaniko build)
+RUN install -dv --mode=775 --owner=postgres --group=postgres /var/run/postgresql /run/postgresql
+
 # Initialize the database
 RUN su - postgres -c "/usr/pgsql-10/bin/pg_ctl init"
 


### PR DESCRIPTION
When building on Kaniko the /var/run/postgresql directory is not preserved because Kaniko excludes /var/run by default due to Kubernetes secrets (and others) stored in /var/log.  Creating the directory in /run directly will not exclude the directory and will copy it out to the final image.  This works because /var/run is a symlink to /run.  Tested with a Kaniko build on docker, a Gitlab runner on NRP-Nautilus, and a bare Docker container.