### PR TITLE
Fixes for Kaniko build on GitLab runner 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,9 @@ COPY rsyslog/owamp-syslog.conf /etc/rsyslog.d/owamp-syslog.conf
 
 # -----------------------------------------------------------------------------
 
+# Create httpd run directory for httpd (using /run for Kaniko build on GitLab runner)
+RUN install -dv /run/httpd
+
 RUN mkdir -p /var/log/supervisor 
 ADD supervisord.conf /etc/supervisord.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV PGVERSION 10
 ENV PGDATA /var/lib/pgsql/10/data
 
 # Create run directory (using /run for Kaniko build)
-RUN install -dv --mode=775 --owner=postgres --group=postgres /var/run/postgresql /run/postgresql
+RUN install -dv --mode=775 --owner=postgres --group=postgres /run/postgresql
 
 # Initialize the database
 RUN su - postgres -c "/usr/pgsql-10/bin/pg_ctl init"

--- a/docker-compose.systemd.yml
+++ b/docker-compose.systemd.yml
@@ -1,6 +1,7 @@
 version: "3.8"
 services:
   testpoint:
+    image: perfsonar/testpoint:v4.4.2-systemd
     build:
       context: .
       dockerfile: systemd/Dockerfile

--- a/docker-compose.systemd.yml
+++ b/docker-compose.systemd.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   testpoint:
-    image: perfsonar/testpoint:v4.4.2-systemd
+    image: perfsonar/testpoint:v4.4.4-systemd
     build:
       context: .
       dockerfile: systemd/Dockerfile

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -22,19 +22,31 @@ command=/usr/bin/pidproxy /var/run/httpd.pid /bin/bash -c "/usr/sbin/httpd -DFOR
 
 [program:pscheduler-ticker]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/ticker --daemon --pid-file /var/run/pscheduler-ticker.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/ticker --pid-file /var/run/pscheduler-ticker.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:pscheduler-archiver]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/archiver --daemon --pid-file /var/run/pscheduler-archiver.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/archiver --pid-file /var/run/pscheduler-archiver.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:pscheduler-scheduler]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/scheduler --daemon --pid-file /var/run/pscheduler-scheduler.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/scheduler --pid-file /var/run/pscheduler-scheduler.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:pscheduler-runner]
 chown=pscheduler:pscheduler
-command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/runner --daemon --pid-file /var/run/pscheduler-runner.pid --dsn @/etc/pscheduler/database/database-dsn 
+command=/usr/bin/python3 /usr/libexec/pscheduler/daemons/runner --pid-file /var/run/pscheduler-runner.pid --dsn @/etc/pscheduler/database/database-dsn 
+redirect_stderr=true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
 
 [program:psconfig_pscheduler_agent]
 chown=perfsonar:perfsonar


### PR DESCRIPTION
Fixes for #32 

Only create run folders in `/run` so Kaniko does not ignore them and add `/run/httpd`.

GitLab runner must fixup `/run` with 
```
mv /var/run /run && ln -sf -v ../run /var/run
```
in the `gitlab-ci.yaml` under `script:` before calling Kaniko.
