### PR TITLE
5.2.2

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -39,6 +39,7 @@ command=/usr/bin/python3 /usr/lib/pscheduler/daemons/ticker --dsn @/etc/pschedul
 redirect_stderr=true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
+autorestart=true
 
 [program:pscheduler-archiver]
 chown=pscheduler:pscheduler
@@ -54,6 +55,7 @@ command=/usr/bin/python3 /usr/lib/pscheduler/daemons/scheduler --dsn @/etc/psche
 redirect_stderr=true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
+autorestart=true
 
 [program:pscheduler-runner]
 chown=pscheduler:pscheduler
@@ -61,6 +63,7 @@ command=/usr/bin/python3 /usr/lib/pscheduler/daemons/runner --dsn @/etc/pschedul
 redirect_stderr=true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
+autorestart=true
 
 [program:psconfig-pscheduler-agent]
 chown=perfsonar:perfsonar

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,15 @@
 [supervisord]
 nodaemon=true
 
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
 [program:rsyslog]
 command=rsyslogd -n 
 redirect_stderr=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -67,4 +67,4 @@ command=/usr/bin/python3 /usr/lib/perfsonar/psconfig/bin/psconfig_pscheduler_age
 
 [program:perfsonar-host-exporter]
 chown=perfsonar:perfsonar
-command=/usr/bin/python3 /usr/lib/perfsonar/host_metrics/perfsonar_host_exporter
+command=/usr/bin/python3 /usr/lib/perfsonar/host_metrics/perfsonar_host_exporter.py

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -69,3 +69,19 @@ command=/usr/bin/python3 /usr/lib/perfsonar/psconfig/bin/psconfig_pscheduler_age
 [program:perfsonar-host-exporter]
 chown=perfsonar:perfsonar
 command=/usr/bin/python3 /usr/lib/perfsonar/host_metrics/perfsonar_host_exporter.py
+
+[group:stage_one]
+programs=rsyslog
+priority=10
+
+[group:stage_two]
+programs=owamp-server,twamp-server,postgresql
+priority=20
+
+[group:stage_three]
+programs=pscheduler-ticker,pscheduler-archiver,pscheduler-scheduler,pscheduler-runner,apache2
+priority=30
+
+[group:stage_four]
+programs=psconfig-pscheduler-agent,perfsonar-host-exporter,perfsonar-lsregistrationdaemon
+priority=40

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -7,11 +7,11 @@ redirect_stderr=true
 
 [program:owamp-server]
 chown=owamp:owamp
-command=/usr/sbin/owampd -c /etc/owamp-server -R /var/run
+command=/usr/sbin/owampd -c /etc/owamp-server -R /var/run -Z
 
 [program:twamp-server]
 chown=twamp:twamp
-command=/usr/sbin/twampd -c /etc/twamp-server -R /var/run
+command=/usr/sbin/twampd -c /etc/twamp-server -R /var/run -Z
 
 [program:perfsonar-lsregistrationdaemon]
 chown=perfsonar:perfsonar

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -46,6 +46,7 @@ command=/usr/bin/python3 /usr/lib/pscheduler/daemons/archiver --dsn @/etc/psched
 redirect_stderr=true
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
+autorestart=true
 
 [program:pscheduler-scheduler]
 chown=pscheduler:pscheduler


### PR DESCRIPTION
Setting up perfsonar/testpoint container on kubernetes led me here. I spoke with @mfeit-internet2 about the changes.
Flags were needed for owamp/twamp to run in the foreground so supervisord could manage them
An extension was missed for the host-exporter
The archiver would occasionally just exit with 0, set it to autorestart
I prioritized the order based upon my conversation with Mark.

 